### PR TITLE
[fix] both pods and boosters now obey the 'auto-radius' option

### DIFF
--- a/core/src/net/sf/openrocket/rocketcomponent/ParallelStage.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/ParallelStage.java
@@ -218,11 +218,11 @@ public class ParallelStage extends AxialStage implements FlightConfigurableCompo
 		super.update();
 		
 		if( this.autoRadialPosition ){
-			AxialStage parentStage = (AxialStage)this.parent;
-			if( null == parentStage ){
+			ComponentAssembly parentAssembly = (ComponentAssembly)this.parent;
+			if( null == parentAssembly ){
 				this.radialPosition_m = this.getOuterRadius();
 			}else{
-				this.radialPosition_m = this.getOuterRadius() + parentStage.getOuterRadius();
+				this.radialPosition_m = this.getOuterRadius() + parentAssembly.getOuterRadius();
 			}
 		}
 	}

--- a/core/src/net/sf/openrocket/rocketcomponent/PodSet.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/PodSet.java
@@ -238,4 +238,17 @@ public class PodSet extends ComponentAssembly implements RingInstanceable {
 		fireComponentChangeEvent(ComponentChangeEvent.BOTH_CHANGE);
 	}
 	
+	@Override
+	protected void update(){
+		super.update();
+
+		if( this.autoRadialPosition){
+			ComponentAssembly parentAssembly = (ComponentAssembly)this.parent;
+			if( null == parentAssembly ){
+				this.radialPosition_m = this.getOuterRadius();
+			}else{
+				this.radialPosition_m = this.getOuterRadius() + parentAssembly.getOuterRadius();
+			}
+		}
+	}
 }


### PR DESCRIPTION
- update ParallelStage#update to use the parent-class
  which contains 'getOuterRadius'