### PR TITLE
[fix] simulations now correctly count motors on boosters and pods

### DIFF
--- a/core/src/net/sf/openrocket/simulation/MotorClusterState.java
+++ b/core/src/net/sf/openrocket/simulation/MotorClusterState.java
@@ -129,7 +129,9 @@ public class MotorClusterState {
 		if( this.currentState.isThrusting() ) {
 			double motorStartTime = this.getMotorTime( startSimulationTime);
 			double motorEndTime = this.getMotorTime( endSimulationTime);
-			return this.motorCount * motor.getAverageThrust( motorStartTime, motorEndTime );
+			
+			int instanceCount = this.config.getMount().getLocations().length;
+			return instanceCount * motor.getAverageThrust( motorStartTime, motorEndTime );
 		}else{
 			return 0.00;
 		}


### PR DESCRIPTION
- thrust now counts motors on InnerTubes AND BodyTubes.